### PR TITLE
Fixed dropped wrong item

### DIFF
--- a/src/main/java/techreborn/blocks/BlockDigitalChest.java
+++ b/src/main/java/techreborn/blocks/BlockDigitalChest.java
@@ -3,6 +3,7 @@ package techreborn.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -36,11 +37,7 @@ public class BlockDigitalChest extends BlockMachineBase {
     }
 
     @Override
-    public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
-    {
-        super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
-        p_149749_1_.removeTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
-    }
+    protected void dropInventory(World world, int x, int y, int z) {}
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z,

--- a/src/main/java/techreborn/blocks/BlockDigitalChest.java
+++ b/src/main/java/techreborn/blocks/BlockDigitalChest.java
@@ -2,6 +2,7 @@ package techreborn.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -32,6 +33,13 @@ public class BlockDigitalChest extends BlockMachineBase {
     @Override
     public TileEntity createNewTileEntity(World p_149915_1_, int p_149915_2_) {
         return new TileDigitalChest();
+    }
+
+    @Override
+    public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
+    {
+        super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
+        p_149749_1_.removeTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
     }
 
     @Override


### PR DESCRIPTION
Overrided dropInventory() method to prevent it from dropping the items in the chest's inventory